### PR TITLE
shorten TJA export time, especially for misaligned TJA

### DIFF
--- a/src/file_format_tja.h
+++ b/src/file_format_tja.h
@@ -504,6 +504,12 @@ namespace TJA
 		std::string Lyric;
 	};
 
+	struct ConvertedGoGoChange
+	{
+		Beat TimeWithinMeasure;
+		b8 IsGogo;
+	};
+
 	struct ConvertedScrollType
 	{
 		Beat TimeWithinMeasure;
@@ -530,6 +536,7 @@ namespace TJA
 		// BUG: Can't actually change inbetween measures..?
 		std::vector<ConvertedBarLineChange> BarLineChanges;
 		std::vector<ConvertedLyricChange> LyricChanges;
+		std::vector<ConvertedGoGoChange> GoGoChanges;
 	};
 
 	struct ConvertedGoGoRange
@@ -551,7 +558,7 @@ namespace TJA
 		std::vector<ConvertedGoGoRange> GoGoRanges;
 	};
 
-	void ConvertConvertedMeasuresToParsedCommands(const std::vector<TJA::ConvertedMeasure>& inMeasures, const std::vector<ConvertedGoGoRange>& inGoGo, std::vector<TJA::ParsedChartCommand>& outCommands);
+	void ConvertConvertedMeasuresToParsedCommands(const std::vector<TJA::ConvertedMeasure>& inMeasures, std::vector<TJA::ParsedChartCommand>& outCommands);
 
 	ConvertedCourse ConvertParsedToConvertedCourse(const ParsedTJA& inContent, const ParsedCourse& inCourse);
 }

--- a/src/peepo_drum_kit/chart.cpp
+++ b/src/peepo_drum_kit/chart.cpp
@@ -412,12 +412,21 @@ namespace PeepoDrumKit
 					outConvertedMeasure->LyricChanges.push_back(TJA::ConvertedLyricChange { (inLyric.BeatTime - outConvertedMeasure->StartTime), inLyric.Lyric });
 			}
 
-			std::vector<TJA::ConvertedGoGoRange> outConvertedGoGoRanges;
-			outConvertedGoGoRanges.reserve(inCourse.GoGoRanges.size());
+			// For go-go time events, convert each range to a pair of start & end changes
 			for (const GoGoRange& gogo : inCourse.GoGoRanges)
-				outConvertedGoGoRanges.push_back(TJA::ConvertedGoGoRange { gogo.BeatTime, (gogo.BeatTime + Max(Beat::Zero(), gogo.BeatDuration)) });
+			{
+				// start
+				TJA::ConvertedMeasure* outConvertedMeasureStart = tryFindMeasureForBeat(outConvertedMeasures, gogo.BeatTime);
+				if (assert(outConvertedMeasureStart != nullptr); outConvertedMeasureStart != nullptr)
+					outConvertedMeasureStart->GoGoChanges.push_back(TJA::ConvertedGoGoChange{ (gogo.BeatTime - outConvertedMeasureStart->StartTime), true });
+				// end
+				const Beat endTime = gogo.BeatTime + Max(Beat::Zero(), gogo.BeatDuration);
+				TJA::ConvertedMeasure* outConvertedMeasureEnd = tryFindMeasureForBeat(outConvertedMeasures, endTime);
+				if (assert(outConvertedMeasureEnd != nullptr); outConvertedMeasureEnd != nullptr)
+					outConvertedMeasureEnd->GoGoChanges.push_back(TJA::ConvertedGoGoChange{ (endTime - outConvertedMeasureEnd->StartTime), false });
+			}
 
-			TJA::ConvertConvertedMeasuresToParsedCommands(outConvertedMeasures, outConvertedGoGoRanges, outCourse.ChartCommands);
+			TJA::ConvertConvertedMeasuresToParsedCommands(outConvertedMeasures, outCourse.ChartCommands);
 		}
 
 		return true;

--- a/src/peepo_drum_kit/chart.cpp
+++ b/src/peepo_drum_kit/chart.cpp
@@ -338,11 +338,14 @@ namespace PeepoDrumKit
 
 			static constexpr auto tryFindMeasureForBeat = [](std::vector<TJA::ConvertedMeasure>& measures, Beat beatToFind) -> TJA::ConvertedMeasure*
 			{
-				// TODO: Optimize using binary search
-				for (auto& measure : measures)
-					if (beatToFind >= measure.StartTime && beatToFind < (measure.StartTime + abs(measure.TimeSignature.GetDurationPerBar())))
-						return &measure;
-				return nullptr;
+				static constexpr auto isMoreBeat = [](const TJA::ConvertedMeasure& lhs, const TJA::ConvertedMeasure& rhs)
+				{
+					return lhs.StartTime > rhs.StartTime;
+				};
+				// Binary search in descending (ascending but reversed) list
+				// if found: `it` is the last element such that `beatToFind >= it->StartTime`
+				auto it = std::lower_bound(measures.rbegin(), measures.rend(), TJA::ConvertedMeasure { beatToFind }, isMoreBeat);
+				return (it == measures.rend()) ? nullptr : &*it;
 			};
 
 			for (const TempoChange& inTempoChange : inCourse.TempoMap.Tempo)


### PR DESCRIPTION
## Changed TJA Exporting Behaviors

* fix non-minimum `0` note symbols in exported TJA

See commit messages for more changelog.

## Test cases

https://discord.com/channels/722513061419810946/722515657345990659/1338174181329735730

Properly aligned chart:
[Untitled Ongaku.tja](https://github.com/user-attachments/files/18757237/Untitled.Ongaku.tja.txt)

The same chart but some measures misaligned by 1 tick (1/20160th):
[Untitled Ongaku 2.tja](https://github.com/user-attachments/files/18757243/Untitled.Ongaku.2.tja.txt)

* Before: Takes 13 minutes ± 5 seconds to save (debug mode)
* After: Takes 1.2 ± 0.3 second to save (debug mode) → 780x faster for this case!