### PR TITLE
better angled complex-valued `#SCROLL`

### DIFF
--- a/src/core_types.h
+++ b/src/core_types.h
@@ -512,16 +512,14 @@ constexpr void AnimateExponentialVec2(vec2* inOutCurrent, vec2 target, f32 anima
 	AnimateExponentialF32(&inOutCurrent->y, target.y, animationSpeed, deltaTime);
 }
 
-#if 0 // TODO: Do all this fun stuff
-inline vec2 Normalize(vec2 value) { ...; }
-inline f32 Dot(vec2 a, vec2 b) { ... }
-inline f32 Length(vec2 value) { ... }
-inline f32 LengthSqr(vec2 value) { ... }
+constexpr f32 Dot(vec2 a, vec2 b) { return (a.x * b.x) + (a.y * b.y); }
+constexpr f32 LengthSqr(vec2 value) { return Dot(value, value); }
+inline f32 Length(vec2 value) { return std::sqrt(LengthSqr(value)); }
+inline vec2 Normalize(vec2 value) { value / Length(value); }
 inline f32 Distance(f32 a, f32 b) { return Absolute(a - b); }
-inline f32 Distance(vec2 a, vec2 b) { ... }
+inline f32 Distance(vec2 a, vec2 b) { return Length(a - b); }
 inline vec2 LookAtDirection(vec2 from, vec2 target) { return Normalize(target - from); }
-inline vec2 Reflect(vec2 value, vec2 normal) { ... }
-#endif
+constexpr vec2 Reflect(vec2 value, vec2 normal) { return value - normal * Dot(value, normal) * 2; }
 
 template <typename T>
 struct BezierKeyFrame

--- a/src/peepo_drum_kit/chart_editor_widgets.h
+++ b/src/peepo_drum_kit/chart_editor_widgets.h
@@ -265,7 +265,7 @@ namespace PeepoDrumKit
 	{
 		GameCamera Camera = {};
 
-		struct DeferredNoteDrawData { f32 LaneHeadX, LaneTailX, LaneHeadY, LaneTailY; const Note* OriginalNote; Time NoteStartTime, NoteEndTime; };
+		struct DeferredNoteDrawData { f32 LaneHeadX, LaneTailX, LaneHeadY, LaneTailY; Complex ScrollSpeed; const Note* OriginalNote; Time NoteStartTime, NoteEndTime; };
 		std::vector<DeferredNoteDrawData> ReverseNoteDrawBuffer;
 
 		void DrawGui(ChartContext& context, Time animatedCursorTime);

--- a/src/peepo_drum_kit/chart_editor_widgets_game.cpp
+++ b/src/peepo_drum_kit/chart_editor_widgets_game.cpp
@@ -303,6 +303,9 @@ namespace PeepoDrumKit
 		Tempo Tempo;
 		Complex ScrollSpeed;
 		ScrollMethod ScrollType;
+		struct Tempo TempoTail;
+		Complex ScrollSpeedTail;
+		ScrollMethod ScrollTypeTail;
 	};
 
 	template <typename Func>
@@ -323,6 +326,9 @@ namespace PeepoDrumKit
 				TempoOrDefault(tempoChangeIt.Next(course.TempoMap.Tempo.Sorted, beat)),
 				ScrollOrDefault(scrollChangeIt.Next(course.ScrollChanges.Sorted, beat)),
 				ScrollTypeOrDefault(scrollTypeIt.Next(course.ScrollTypes.Sorted, beat)),
+				TempoOrDefault(tempoChangeIt.Next(course.TempoMap.Tempo.Sorted, beatTail)),
+				ScrollOrDefault(scrollChangeIt.Next(course.ScrollChanges.Sorted, beatTail)),
+				ScrollTypeOrDefault(scrollTypeIt.Next(course.ScrollTypes.Sorted, beatTail)),
 				});
 		}
 	}
@@ -506,7 +512,7 @@ namespace PeepoDrumKit
 			{
 				const vec2 laneOrigin = Camera.GetHitCircleCoordinates(jposScrollChanges, cursorTimeOrAnimated, tempoChanges);
 				vec2 laneHead = Camera.GetAbsoluteNoteCoordinates(cursorTimeOrAnimated, cursorHBScrollBeatOrAnimated, it.TimeHead, it.BeatHead, it.TimeHeadOffset, it.Tempo, it.ScrollSpeed, it.ScrollType, tempoChanges, jposScrollChanges);
-				vec2 laneTail = Camera.GetAbsoluteNoteCoordinates(cursorTimeOrAnimated, cursorHBScrollBeatOrAnimated, it.TimeTail, it.BeatTail, it.TimeTailOffset, it.Tempo, it.ScrollSpeed, it.ScrollType, tempoChanges, jposScrollChanges);
+				vec2 laneTail = Camera.GetAbsoluteNoteCoordinates(cursorTimeOrAnimated, cursorHBScrollBeatOrAnimated, it.TimeTail, it.BeatTail, it.TimeTailOffset, it.TempoTail, it.ScrollSpeedTail, it.ScrollTypeTail, tempoChanges, jposScrollChanges);
 
 				b8 isVisible = true;
 

--- a/src/peepo_drum_kit/chart_editor_widgets_game.cpp
+++ b/src/peepo_drum_kit/chart_editor_widgets_game.cpp
@@ -117,12 +117,14 @@ namespace PeepoDrumKit
 				: SprID::Game_Note_DrumrollLong);
 		const SprInfo sprInfo = gfx.GetInfo(spr);
 
-		const f32 centerL = Min(centerHead.x, centerTail.x);
-		const f32 centerR = Max(centerHead.x, centerTail.x);
-		const f32 midScaleX = ((centerR - centerL) / (sprInfo.SourceSize.x)) * 3.0f;
+		const f32 midScaleX = (Distance(centerTail, centerHead) / (sprInfo.SourceSize.x)) * 3.0f;
 
 		const SprStretchtOut split = StretchMultiPartSpr(gfx, spr,
-			SprTransform::FromCenter(camera.WorldToScreenSpace((centerHead + centerTail) / 2.0f), vec2(camera.WorldToScreenScale(1.0f))), colorTint,
+			SprTransform::FromCenter(
+				camera.WorldToScreenSpace((centerHead + centerTail) / 2.0f),
+				vec2(camera.WorldToScreenScale(1.0f)),
+				AngleBetween(centerTail, centerHead)),
+				colorTint,
 			SprStretchtParam { 1.0f, midScaleX, 1.0f }, 3);
 
 		for (size_t i = 0; i < 3; i++)
@@ -155,14 +157,15 @@ namespace PeepoDrumKit
 		{
 			const SprInfo sprInfo = gfx.GetInfo(spr);
 
-			// BUG: Incorrect middle part scaling if the drumroll is too short
 			const f32 midAlignmentOffset = (seType == NoteSEType::DrumrollBig) ? 136.0f : 68.0f;
-			const f32 centerL = Min(centerHead.x, centerTail.x);
-			const f32 centerR = Max(centerHead.x, centerTail.x);
-			const f32 midScaleX = ((centerR - centerL - midAlignmentOffset) / (sprInfo.SourceSize.x)) * 3.0f;
+			const f32 midScaleX = (ClampBot(Distance(centerTail, centerHead) - midAlignmentOffset, 0.0f) / (sprInfo.SourceSize.x)) * 3.0f;
 
 			const SprStretchtOut split = StretchMultiPartSpr(gfx, spr,
-				SprTransform::FromCenter(camera.WorldToScreenSpace((centerHead + centerTail) / 2.0f), vec2(camera.WorldToScreenScale(1.0f))), 0xFFFFFFFF,
+				SprTransform::FromCenter(
+					camera.WorldToScreenSpace((centerHead + centerTail) / 2.0f),
+					vec2(camera.WorldToScreenScale(1.0f)),
+					AngleBetween(centerTail, centerHead)), // TODO: only rotate the mid part?
+				0xFFFFFFFF,
 				SprStretchtParam { 1.0f, midScaleX, 1.0f }, 3);
 
 			for (size_t i = 0; i < 3; i++)


### PR DESCRIPTION
## Test Cases

[360 no Streamu.tja](https://github.com/user-attachments/files/18789771/360.no.Streamu.tja.txt)

https://github.com/user-attachments/assets/93eb22a5-c289-40de-8478-d2bfe8fb1c73

* Note: Used faced notes to show the note angle
* After: correct balloon-type note position, correct flying note path

[Nobibar.tja](https://github.com/user-attachments/files/18789770/Nobibar.tja.txt)

https://github.com/user-attachments/assets/5e9018e9-ff02-4419-bda3-f9129b3f8391

* After: flying note path is fixed after the note has been hit

Stretchable bar notes:
![{B3199BC5-3790-4571-9649-11E81C933D29}](https://github.com/user-attachments/assets/291b2d77-8202-4a40-ade0-d801dad1520c)

TaikoJiro 2–style rotated bar lines:
![{F14CD073-21A2-4166-97BC-025A31EC8CB5}](https://github.com/user-attachments/assets/2d2508bf-1e46-4503-a843-6f8cceff3930)
