### PR TITLE
fix i18n ini file space issues

### DIFF
--- a/src/peepo_drum_kit/chart_editor_i18n.cpp
+++ b/src/peepo_drum_kit/chart_editor_i18n.cpp
@@ -211,7 +211,7 @@ namespace PeepoDrumKit::i18n
 			if (keyValue.Key.size() != 13 || keyValue.Key.substr(0, 5) != "HASH_") return;
 			try {
 				u32 hash = std::stoul(std::string(keyValue.Key.substr(5)), nullptr, 16);
-				HashStringMap[hash] = keyValue.Value;
+				HashStringMap[hash] = keyValue.ValueUntrimmed;
 			}
 			catch (std::exception _e)
 			{


### PR DESCRIPTION
Fix the remaining issue of 0auBSQ/PeepoDrumKit#11.

## How It Works

if the spaces at the left of `=` is not more than the spaces at the right, the spaces at the right are removed by the amount of spaces at the left.

```
input → key, value, valueUntrimmed
`  KEY= value `   → `KEY`, `value`, ` value `
`  KEY = value `  → `KEY`, `value`, `value `
`  KEY =  value ` → `KEY`, `value`, ` value `
`  KEY  = value ` → `KEY`, `value`, ` value `
`  KEY  =value  ` → `KEY`, `value`, `value  `
```