### PR TITLE
Inappropriate Paralleling of Countries and Regions

### DIFF
--- a/locales/zh-cn.ini
+++ b/locales/zh-cn.ini
@@ -1,5 +1,5 @@
 [Info]
-Name = 中文（中国）
+Name = 中文（中国大陆）
 Lang = zh-cn
 Font = NotoSansCJKsc-Regular.otf
 

--- a/locales/zh-tw.ini
+++ b/locales/zh-tw.ini
@@ -1,5 +1,5 @@
 [Info]
-Name = 中文（台灣）
+Name = 中文（中國台灣）
 Lang = zh-tw
 Font = NotoSansCJKtc-Regular.otf
 

--- a/src/peepo_drum_kit/chart_editor_i18n.cpp
+++ b/src/peepo_drum_kit/chart_editor_i18n.cpp
@@ -84,7 +84,7 @@ namespace PeepoDrumKit::i18n
 			std::fstream localeFile("locales/zh-cn.ini", std::ios::out | std::ios::trunc);
 
 			localeFile << "[Info]" << std::endl;
-			localeFile << u8"Name = 中文（中国）" << std::endl;
+			localeFile << u8"Name = 中文（中国大陆）" << std::endl;
 			localeFile << "Lang = zh-cn" << std::endl;
 			// TODO: Replace this with https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/13_NotoSansMonoCJKsc.zip
 			localeFile << "Font = NotoSansCJKsc-Regular.otf" << std::endl << std::endl;
@@ -102,7 +102,7 @@ namespace PeepoDrumKit::i18n
 			std::fstream localeFile("locales/zh-tw.ini", std::ios::out | std::ios::trunc);
 
 			localeFile << "[Info]" << std::endl;
-			localeFile << u8"Name = 中文（台灣）" << std::endl;
+			localeFile << u8"Name = 中文（中國台灣）" << std::endl;
 			localeFile << "Lang = zh-tw" << std::endl;
 			// TODO: Replace this with https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/14_NotoSansMonoCJKtc.zip
 			localeFile << "Font = NotoSansCJKtc-Regular.otf" << std::endl << std::endl;


### PR DESCRIPTION
China and Taiwan cannot be paralleled directly under “One China” Principle based on the United Nations general assembly resolution 2758. We may parallel Mainland of China and Taiwan, China with other countries and regions.
If this is not merged. I will lead other Chinese to protest and boycott against this program.