### PR TITLE
fix crashes and errors when parsing complex value

### DIFF
--- a/src/core_string.cpp
+++ b/src/core_string.cpp
@@ -122,6 +122,6 @@ namespace ASCII
 	b8 TryParseCPX(std::string_view string, Complex& out) {
 		std::istringstream in(std::string{string});
 		in >> out;
-		return in.good();
+		return static_cast<bool>(in); // allow eof, reject fail & bad
 	}
 }

--- a/src/core_types.h
+++ b/src/core_types.h
@@ -340,10 +340,12 @@ struct Complex {
 		f32 real = 0.0f;
 		f32 imag = 0.0f;
 #define PAT_APLUSB_RE "[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?(?![iI.\\d])"
-#define PAT_APLUSB_IM "[+-]?(?:(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?)?[iI]"
-		std::regex aplusb("^(?=[iI.\\d+-])(" PAT_APLUSB_RE ")?\\s*(" PAT_APLUSB_IM ")?$");
+#define PAT_APLUSB_IM "[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?[iI]"
+#define PAT_APLUSB_IM_UNIT "[+-]?[iI]"
+		std::regex aplusb("^(?=[iI.\\d+-])(" PAT_APLUSB_RE ")?\\s*(?:(" PAT_APLUSB_IM ")|(" PAT_APLUSB_IM_UNIT "))?$");
 #undef PAT_APLUSB_RE
 #undef PAT_APLUSB_IM
+#undef PAT_APLUSB_IM_UNIT
 		std::string input;
 		in >> input;
 
@@ -355,6 +357,9 @@ struct Complex {
 			}
 			if (matches[2].length() > 0) {
 				imag = std::stof(matches[2]);
+			}
+			else if (matches[3].length() > 0) { // +i / -i / i
+				imag = ((matches[3].first[0] == '-') ? -1 : 1);
 			}
 		}
 		else {


### PR DESCRIPTION
## Fixed Issues

* fix crash and wrong result when parsing `<a>+i` or `<a>-i` complex values
* fix false invalid-input warns for all TJA headers/commands with complex value argument

## Test Cases

Same as 0auBSQ/OpenTaiko#672

[Circular Scroll.tja](https://github.com/user-attachments/files/18945951/Circular.Scroll.tja.txt)

To see the warning list, click "Test Menu" → "Show TJA Import Test", then navigate to "TJA Import Test" → "File Content", and then paste the TJA content into the editor box.