### PR TITLE
Fix known issues of v1.2 

### DIFF
--- a/src/peepo_drum_kit/chart_editor.cpp
+++ b/src/peepo_drum_kit/chart_editor.cpp
@@ -663,7 +663,7 @@ namespace PeepoDrumKit
 
 						for (std::unique_ptr<ChartCourse>& course : context.Chart.Courses)
 						{
-							char buffer[64]; sprintf_s(buffer, "%s \xe2\x98\x85%d%s %s###Course_%p",
+							char buffer[64]; sprintf_s(buffer, u8"%s ★%d%s %s###Course_%p",
 								UI_StrRuntime(DifficultyTypeNames[EnumToIndex(course->Type)]),
 								static_cast<i32>(course->Level), 
 								(course->Decimal == DifficultyLevelDecimal::None) ? "" : ((course->Decimal >= DifficultyLevelDecimal::PlusThreshold) ? "+" : ""),

--- a/src/peepo_drum_kit/chart_editor.cpp
+++ b/src/peepo_drum_kit/chart_editor.cpp
@@ -663,7 +663,7 @@ namespace PeepoDrumKit
 
 						for (std::unique_ptr<ChartCourse>& course : context.Chart.Courses)
 						{
-							char buffer[64]; sprintf_s(buffer, u8"%s ★%d%s %s###Course_%p",
+							char buffer[96]; sprintf_s(buffer, u8"%s ★%d%s %s###Course_%p",
 								UI_StrRuntime(DifficultyTypeNames[EnumToIndex(course->Type)]),
 								static_cast<i32>(course->Level), 
 								(course->Decimal == DifficultyLevelDecimal::None) ? "" : ((course->Decimal >= DifficultyLevelDecimal::PlusThreshold) ? "+" : ""),

--- a/src/peepo_drum_kit/chart_editor.cpp
+++ b/src/peepo_drum_kit/chart_editor.cpp
@@ -972,16 +972,6 @@ namespace PeepoDrumKit
 			Gui::End();
 		}
 
-		if (PersistentApp.LastSession.ShowWindow_ChartStats)
-		{
-			if (Gui::Begin(UI_WindowName("TAB_CHART_STATS"), &PersistentApp.LastSession.ShowWindow_ChartStats, ImGuiWindowFlags_None))
-			{
-				chartStatsWindow.DrawGui(context);
-			}
-			if (focusChartStatsWindowNextFrame) { focusChartStatsWindowNextFrame = false; Gui::SetWindowFocus(); }
-			Gui::End();
-		}
-
 		if (PersistentApp.LastSession.ShowWindow_Settings)
 		{
 			if (Gui::Begin(UI_WindowName("TAB_SETTINGS"), &PersistentApp.LastSession.ShowWindow_Settings, ImGuiWindowFlags_None))
@@ -1042,6 +1032,16 @@ namespace PeepoDrumKit
 				OpenLoadJacketFileDialog(context.Undo);
 		}
 		Gui::End();
+
+		if (PersistentApp.LastSession.ShowWindow_ChartStats)
+		{
+			if (Gui::Begin(UI_WindowName("TAB_CHART_STATS"), &PersistentApp.LastSession.ShowWindow_ChartStats, ImGuiWindowFlags_None))
+			{
+				chartStatsWindow.DrawGui(context);
+			}
+			if (focusChartStatsWindowNextFrame) { focusChartStatsWindowNextFrame = false; Gui::SetWindowFocus(); }
+			Gui::End();
+		}
 
 #if PEEPO_DEBUG // DEBUG: Manually submit debug window before the timeline window is drawn for better tab ordering
 		if (Gui::Begin(UI_WindowName("TAB_TIMELINE_DEBUG"))) { /* ... */ } Gui::End();
@@ -1311,6 +1311,7 @@ namespace PeepoDrumKit
 
 			Gui::DockBuilderDockWindow(UI_WindowName("TAB_UNDO_HISTORY"), dock.TopRight);
 			Gui::DockBuilderDockWindow(UI_WindowName("TAB_CHART_PROPERTIES"), dock.TopRight);
+			Gui::DockBuilderDockWindow(UI_WindowName("TAB_CHART_STATS"), dock.TopRight);
 
 			Gui::DockBuilderDockWindow(UI_WindowName("TAB_INSPECTOR"), dock.TopRightBot);
 		}

--- a/src/peepo_drum_kit/chart_editor_context.h
+++ b/src/peepo_drum_kit/chart_editor_context.h
@@ -130,8 +130,13 @@ namespace PeepoDrumKit
 
 		inline BeatAndTime GetCursorBeatAndTime(bool truncTo0) const
 		{
-			if (SongVoice.GetIsPlaying()) { const Time t = (SongVoice.GetPositionSmooth() + Chart.SongOffset); return { ChartSelectedCourse->TempoMap.TimeToBeat(t, truncTo0), t }; }
-			else { const Beat b = CursorBeatWhilePaused; return { b, ChartSelectedCourse->TempoMap.BeatToTime(b) }; }
+			return GetCursorBeatAndTime(ChartSelectedCourse, truncTo0);
+		}
+
+		inline BeatAndTime GetCursorBeatAndTime(const ChartCourse* course, bool truncTo0) const
+		{
+			if (SongVoice.GetIsPlaying()) { const Time t = (SongVoice.GetPositionSmooth() + Chart.SongOffset); return { course->TempoMap.TimeToBeat(t, truncTo0), t }; }
+			else { const Beat b = CursorBeatWhilePaused; return { b, course->TempoMap.BeatToTime(b) }; }
 		}
 
 		inline void SetCursorTime(Time newTime)

--- a/src/peepo_drum_kit/chart_editor_settings_gui.cpp
+++ b/src/peepo_drum_kit/chart_editor_settings_gui.cpp
@@ -1,4 +1,4 @@
-#include "chart_editor_settings_gui.h"
+﻿#include "chart_editor_settings_gui.h"
 
 namespace PeepoDrumKit
 {
@@ -505,7 +505,7 @@ namespace PeepoDrumKit
 					else
 					{
 						// NOTE: Use a chouonpu here instead of a regular minus for a more readable and thicker glyph at smaller font sizes
-						Gui::TextDisabled("\xE3\x83\xBC"); // u8"�[" // "-" // "(None)"
+						Gui::TextDisabled(u8"ー"); // u8"ー" // "-" // "(None)"
 					}
 
 					Gui::PopID();

--- a/src/peepo_drum_kit/chart_editor_widgets.cpp
+++ b/src/peepo_drum_kit/chart_editor_widgets.cpp
@@ -519,6 +519,11 @@ namespace PeepoDrumKit
 					Gui::TextUnformatted(u8"- Add support for editing any unknown TJA headers");
 					Gui::TextUnformatted(u8"- Add support for number-less NOTESDESIGNER: and file-scope usage of numbered NOTESDESIGNER headers");
 					Gui::TextUnformatted(u8"- Fix notes in negative BPM were wrongly flipped horizontally and SENotes in positive BPM were wrongly rotated 180 degree");
+					Gui::TextUnformatted(u8"- (the following are hotfixes)");
+					Gui::TextUnformatted(u8"- Fix crash when player side and count numbers are too long");
+					Gui::TextUnformatted(u8"- Fix compared lanes wrongly used selected lane's beat and time position if their timing commands differ");
+					Gui::TextUnformatted(u8"- Fix flying notes moved with on-going #JPOSSCROLLs again due to reworking of #JPOSSCROLL in v1.2");
+					Gui::TextUnformatted(u8"- Fix undefined default Chart Stats tab docking position since v1.1.1");
 					Gui::TextUnformatted(u8"- (for the full change list, please refer to the commit history)");
 					Gui::TextUnformatted("");
 					Gui::PopFont();
@@ -545,7 +550,7 @@ namespace PeepoDrumKit
 					Gui::TextUnformatted(u8"- #JPOSSCROLL is now visualized and editable as long event");
 					Gui::TextUnformatted(u8"- Widen playback speed range to 10%–200%");
 					Gui::TextUnformatted(u8"- Add Chart Stats tab");
-					Gui::TextUnformatted(u8"- Tweak difficulty number display and remove star view");
+					Gui::TextUnformatted(u8"- Tweak difficulty number display and remove star view for decimal");
 					Gui::TextUnformatted(u8"- Add support of editing Tower charts and view Dan charts");
 					Gui::TextUnformatted(u8"- Add “Insert at Selected Items”, the successor of “Selection to Scroll Changes” which applies to all chart events");
 					Gui::TextUnformatted(u8"- Migrate to Dear ImGui 1.92.0-docking and solve missing font glyph issues");

--- a/src/peepo_drum_kit/chart_editor_widgets.cpp
+++ b/src/peepo_drum_kit/chart_editor_widgets.cpp
@@ -351,7 +351,7 @@ namespace PeepoDrumKit
 		Gui::Property::PropertyTextValueFunc(label, [&]
 		{
 			static constexpr i32 components = 2; // NOTE: Unicode "Rightwards Arrow" U+2192
-			static constexpr std::string_view divisionText = "  \xE2\x86\x92  "; // "  ->  "; // " < > ";
+			static constexpr std::string_view divisionText = u8"  →  "; // "  ->  "; // " < > ";
 			const f32 divisionLabelWidth = Gui::CalcTextSize(Gui::StringViewStart(divisionText), Gui::StringViewEnd(divisionText)).x;
 			const f32 perComponentInputFloatWidth = Floor(((Gui::GetContentRegionAvail().x - divisionLabelWidth) / static_cast<f32>(components)));
 

--- a/src/peepo_drum_kit/chart_editor_widgets_game.cpp
+++ b/src/peepo_drum_kit/chart_editor_widgets_game.cpp
@@ -761,7 +761,7 @@ namespace PeepoDrumKit
 				const Time timeSinceTailHit = TimeSinceNoteHit(it.Tail.Time, cursorTimeOrAnimated);
 				if (IsRegularNote(it.OriginalNote->Type)) {
 					if (timeSinceHeadHit >= Time::Zero())
-						laneHead = laneTail = hitCirclePosLane;
+						laneHead = laneTail = hitCirclePosLane; // temporary value, override when drawn
 					if (timeSinceHeadHit > GetTotalGameNoteHitAnimationDuration(it.OriginalNote->Type))
 						isVisible = false;
 				}
@@ -847,7 +847,9 @@ namespace PeepoDrumKit
 				{
 					// TODO: Instead of offseting the lane x position just draw as HitCenter + PositionOffset directly (?)
 					auto hitAnimation = GetNoteHitPathAnimation(timeSinceHit, Camera.ExtendedLaneWidthFactor(), nLanes, iLane, it->OriginalNote->Type);
-					const vec2 noteCenter = Camera.LaneToWorldSpace(it->LaneHeadX, it->LaneHeadY) + hitAnimation.PositionOffset;
+					const vec2 noteOrigin = (timeSinceHit >= Time::Zero()) ? Camera.GetHitCircleCoordinatesLane(jposScrollChanges, it->NoteEndTime, tempoChanges) // keep flying note's start position
+						: vec2{ it->LaneHeadX, it->LaneHeadY };
+					const vec2 noteCenter = Camera.LaneToWorldSpace(noteOrigin.x, noteOrigin.y) + hitAnimation.PositionOffset;
 
 					if (hitAnimation.AlphaFadeOut >= 1.0f)
 						DrawGamePreviewNote(context.Gfx, Camera, drawList, noteCenter, it->Tempo, it->ScrollSpeed, it->OriginalNote->Type, cursorTimeOrAnimated, hitAnimation, nLanes, iLane);


### PR DESCRIPTION
* fix: increase course tab string buffer to prevent crash due to long player side and count numbers
* fix compared lanes wrongly used selected lane's beat and time position if their timing commands differ
* fix flying notes moved with on-going JPosScrolls due to 6db17c7
* fix undefined default Chart Stats tab docking position
* fix v1.1.1 update note about removed difficulty level decimal star view

The version stays v1.2, but the in-game change logs are updated for users to check.

Test build: <https://github.com/IepIweidieng/PeepoDrumKit/releases/tag/v1.2.0.120120>